### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node-uuid": "~1.4.1",
     "qs": "^0.6.6",
     "redis": "~0.10.3",
-    "request": "~2.40.0",
+    "request": "~2.74.0",
     "simple-benchmark": "^1.0.7",
     "socket.io": "^1.3.5",
     "socket.io-client": "^1.3.5",


### PR DESCRIPTION
meshblu currently has a 22 vulnerable dependency paths, introducing 12 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/octoblu/meshblu) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)